### PR TITLE
Update to latest Snappy library.

### DIFF
--- a/message.go
+++ b/message.go
@@ -66,11 +66,7 @@ func (m *Message) encode(pe packetEncoder) error {
 			m.compressedCache = buf.Bytes()
 			payload = m.compressedCache
 		case CompressionSnappy:
-			tmp, err := snappyEncode(m.Value)
-			if err != nil {
-				return err
-			}
-			m.compressedCache = tmp
+			m.compressedCache = snappyEncode(m.Value)
 			payload = m.compressedCache
 		default:
 			return PacketEncodingError{fmt.Sprintf("Unsupported compression codec: %d", m.Codec)}

--- a/snappy.go
+++ b/snappy.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/golang/snappy/snappy"
+	"github.com/golang/snappy"
 )
 
 var snappyMagic = []byte{130, 83, 78, 65, 80, 80, 89, 0}
 
 // SnappyEncode encodes binary data
-func snappyEncode(src []byte) ([]byte, error) {
+func snappyEncode(src []byte) []byte {
 	return snappy.Encode(nil, src)
 }
 

--- a/snappy_test.go
+++ b/snappy_test.go
@@ -19,10 +19,8 @@ var snappyStreamTestCases = map[string][]byte{
 
 func TestSnappyEncode(t *testing.T) {
 	for src, exp := range snappyTestCases {
-		dst, err := snappyEncode([]byte(src))
-		if err != nil {
-			t.Error("Encoding error: ", err)
-		} else if !bytes.Equal(dst, exp) {
+		dst := snappyEncode([]byte(src))
+		if !bytes.Equal(dst, exp) {
 			t.Errorf("Expected %s to generate %v, but was %v", src, exp, dst)
 		}
 	}


### PR DESCRIPTION
The Snappy library structure was changed to simplify the import
path, code used to be rooted in /snappy/snappy, it is now rooted
in /snappy alongside the readme, etc.  Changing to use the latest
Snappy library to avoid conflicts with projects that rely on
libraries which use later versions of Snappy and the new
import path.

The only semi-substantative change that needed to be made was to
reflect the changed signature of Encode, which no longer returns
an error as encoding cannot fail.
